### PR TITLE
Settings page changes, switch on Map screen

### DIFF
--- a/LookUp/app/(tabs)/map.tsx
+++ b/LookUp/app/(tabs)/map.tsx
@@ -7,6 +7,10 @@ const screenWidth = Dimensions.get('window').width;
 const screenHeight = Dimensions.get('window').height;
 import { CameraView, CameraType, useCameraPermissions } from 'expo-camera';
 import { useBouncingBox } from '@/hooks/useBouncingBox'; // bouncing red box for overlays
+import { Switch } from 'react-native-gesture-handler';
+
+// For plane tracking switch
+import PlaneTrackingToggle from '@/components/PlaneTrackingToggle';
 
 export default function MapScreen() {
   // Default to false for mixed reality mode initially for load on phones
@@ -26,6 +30,11 @@ export default function MapScreen() {
 
   // Get the screen width
   const [placement, setPlacement] = useState<'left' | 'right'>('right');
+
+  // Variables for switch between satellite tracking and plane tracking
+  const [isTrackingPlanes, setIsTrackingPlanes] = useState(true);
+  const toggleTrackingPlanes = () => setIsTrackingPlanes(!isTrackingPlanes);
+  const planeSwitchScale = 1.8; // Change this value to scale the switch
 
   // Tooltip Init
   const tooltipOffset = useRef(new Animated.Value(250)).current; // default on the right side
@@ -155,6 +164,23 @@ export default function MapScreen() {
   // ========================= CAMERA DISPLAY & CONTROL =========================
   return (
     <View style={styles.container}>
+
+      {/* Plane Tracking Toggle Switch */}
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 50,
+          left: 50,
+          zIndex: 201,
+          transform: [{ scale: planeSwitchScale }],
+        }}
+      >
+        <PlaneTrackingToggle
+          value={isTrackingPlanes}
+          onToggle={() => toggleTrackingPlanes()}
+        />
+      </View>
+      {/* End plane tracking toggle switch */}
       
       {/* We check if mixed reality is enabled and permission is ranted, if so - allow for MxR Access. */}
       {isMixedReality ? (

--- a/LookUp/app/(tabs)/settings.tsx
+++ b/LookUp/app/(tabs)/settings.tsx
@@ -6,8 +6,10 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import Slider from '@react-native-community/slider';
+// import Slider from '@/components/Slider'; // this is currently bugged as of .20 version of react. it should be fixed soon, hopefully.
+import { Picker } from '@react-native-picker/picker';
 
-import { TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 // Use global theme context
 import { useAppTheme } from '@/theme/ThemeContext';
@@ -26,6 +28,9 @@ function withGestureHandlerRootView(Component: React.ComponentType) {
 }
 
 function SettingsScreen() {
+  // for Picker
+  const [selectedLanguage, setSelectedLanguage] = useState('');
+
   const [flightRadius, setFlightRadius] = useState(10);
 
   const { theme, toggleTheme } = useAppTheme();
@@ -77,7 +82,25 @@ function SettingsScreen() {
         <ThemedText style={{ marginBottom: 12 }}>Set how far (in miles) to passively scan for nearby flights:</ThemedText>
         <ThemedText style={{ marginBottom: 8 }}>Radius: {flightRadius} miles</ThemedText>
 
-        <TapGestureHandler onActivated={() => {}}>
+        {/* Placeholder picker in lieu of the slider below, since it's got a bug :P.*/}
+        <Picker
+          selectedValue={flightRadius}
+          onValueChange={(itemValue) => setFlightRadius(Number(itemValue))}
+          style={{
+            color: getInterpolatedColor(flightRadius),
+            marginBottom: 8,
+          }}
+        >
+          <Picker.Item label="1" value={1} />
+          <Picker.Item label="5" value={5} />
+          <Picker.Item label="10" value={10} />
+          <Picker.Item label="15" value={15} />
+          <Picker.Item label="20" value={20} />
+          <Picker.Item label="25" value={25} />
+        </Picker>
+
+        {/*
+        <GestureDetector gesture={Gesture.Tap().onEnd(() => {})}>
           <Slider
             value={flightRadius}
             onValueChange={setFlightRadius}
@@ -89,7 +112,8 @@ function SettingsScreen() {
             maximumTrackTintColor="#ccc"
             thumbTintColor={getInterpolatedColor(flightRadius)}
           />
-        </TapGestureHandler>
+        </GestureDetector>
+        */}
 
         <ThemedText style={{ marginTop: 12, color: getInterpolatedColor(flightRadius), fontWeight: '600' }}>
           WARNING: GREATER DETECTION RADIUS MAY INCREASE QUERY TIME
@@ -110,7 +134,6 @@ function SettingsScreen() {
     </View>
   );
 }
-//}
 
 const styles = StyleSheet.create({
   titleContainer: {
@@ -122,8 +145,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    overflowX: 'hidden',
-    overflowY: 'scroll',
   },
   section: {
     paddingHorizontal: 20,

--- a/LookUp/app/_layout.tsx
+++ b/LookUp/app/_layout.tsx
@@ -1,4 +1,5 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';

--- a/LookUp/components/PlaneTrackingToggle.tsx
+++ b/LookUp/components/PlaneTrackingToggle.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+// initialize the variables and types
+export default function PlaneToggle({
+  value,
+  onToggle,
+}: {
+  value: boolean;
+  onToggle: () => void;
+}) {
+
+  // Animation details with effects, interpolations, and styles
+  const animation = useRef(new Animated.Value(value ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.timing(animation, {
+      toValue: value ? 1 : 0,
+      duration: 200,
+      useNativeDriver: false,
+    }).start();
+  }, [value]);
+
+  const translateX = animation.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 30], // adjust based on container/track width
+  });
+
+  const backgroundColor = animation.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['#ccc', '#009688'], // gray to teal
+  });
+
+  // Icon based on the value
+  const icon = value ? '✈️' : '🛰️';
+
+  return (
+    <Pressable onPress={onToggle}>
+      <Animated.View style={[styles.container, { backgroundColor }]}>
+        <Animated.View style={[styles.thumb, { transform: [{ translateX }] }]}>
+          <Text style={styles.icon}>{icon}</Text>
+        </Animated.View>
+      </Animated.View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: 64,
+    height: 32,
+    borderRadius: 16,
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+    backgroundColor: '#ccc',
+  },
+  thumb: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 1,
+  },
+  icon: {
+    fontSize: 16,
+  },
+});

--- a/LookUp/package-lock.json
+++ b/LookUp/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-community/slider": "^4.5.6",
+        "@react-native-picker/picker": "^2.11.0",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "expo": "^53.0.9",
@@ -2487,6 +2488,15 @@
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.6.tgz",
       "integrity": "sha512-UhLPFeqx0YfPLrEz8ffT3uqAyXWu6iqFjohNsbp4cOU7hnJwg2RXtDnYHoHMr7MOkZDVdlLMdrSrAuzY6KGqrg=="
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.0.tgz",
+      "integrity": "sha512-QuZU6gbxmOID5zZgd/H90NgBnbJ3VV6qVzp6c7/dDrmWdX8S0X5YFYgDcQFjE3dRen9wB9FWnj2VVdPU64adSg==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.79.2",

--- a/LookUp/package.json
+++ b/LookUp/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@react-native-community/slider": "^4.5.6",
+    "@react-native-picker/picker": "^2.11.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "expo": "^53.0.9",


### PR DESCRIPTION
Settings page now sports a drop-down menu because slider has depreciated. I'll be checking consistently to see if it's fixed in another update in the future. For now, the dropdown operates the same. It's rough, robust, and not pretty (ha)

furthermore, there's a switch added to the map screen to swap between plane and satellite mode.